### PR TITLE
Fix Vite base path for GitHub Pages deployment

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,11 +4,13 @@ import react from '@vitejs/plugin-react';
 
 export default defineConfig(({ mode }) => {
     const env = loadEnv(mode, '.', '');
+    const isProduction = mode === 'production';
     return {
       server: {
         port: 3000,
         host: '0.0.0.0',
       },
+      base: isProduction ? '/imagedim/' : '/',
       plugins: [react()],
       define: {
         'process.env.API_KEY': JSON.stringify(env.GEMINI_API_KEY),


### PR DESCRIPTION
## Summary
- configure the Vite base path to match the repository name when building for production so GitHub Pages can load the assets

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d6cc95afd88333811a48f906a04974