### PR TITLE
Add GitHub Action to redeploy AI Studio app on push

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,40 @@
+name: Build and redeploy to Google AI Studio
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Use Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build project
+        run: npm run build
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_SERVICE_ACCOUNT_KEY }}
+
+      - name: Install gcloud CLI
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Trigger AI Studio redeploy
+        env:
+          AI_STUDIO_APP_ID: ${{ secrets.AI_STUDIO_APP_ID }}
+        run: npm run deploy:ci

--- a/README.md
+++ b/README.md
@@ -12,9 +12,21 @@ View your app in AI Studio: https://ai.studio/apps/drive/1raorT9ncyeb9b9omWOGyc8
 
 **Prerequisites:**  Node.js
 
-
 1. Install dependencies:
    `npm install`
 2. Set the `GEMINI_API_KEY` in [.env.local](.env.local) to your Gemini API key
 3. Run the app:
    `npm run dev`
+
+## Continuous deployment via GitHub Actions
+
+Pushing to `main` automatically builds the app and triggers a redeploy in Google AI Studio.
+
+### Required GitHub secrets
+
+| Secret | Description |
+| ------ | ----------- |
+| `GCP_SERVICE_ACCOUNT_KEY` | JSON service-account key with permission to deploy the AI Studio app. |
+| `AI_STUDIO_APP_ID` | The app identifier from the AI Studio URL (for example, the value after `/apps/drive/`). |
+
+The workflow authenticates with Google Cloud using the service account, builds the Vite project, and calls the AI Studio deployment API so the hosted app always reflects the latest commit.

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "deploy:ci": "node scripts/trigger-ai-studio-deploy.mjs"
   },
   "dependencies": {
     "react": "^19.1.1",

--- a/scripts/trigger-ai-studio-deploy.mjs
+++ b/scripts/trigger-ai-studio-deploy.mjs
@@ -1,0 +1,54 @@
+import { execSync } from 'node:child_process';
+
+const { AI_STUDIO_APP_ID, GITHUB_SHA } = process.env;
+
+if (!AI_STUDIO_APP_ID) {
+  console.error('Missing required environment variable AI_STUDIO_APP_ID.');
+  process.exit(1);
+}
+
+function getAccessToken() {
+  try {
+    return execSync('gcloud auth print-access-token', {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'inherit'],
+    }).trim();
+  } catch (error) {
+    console.error('Failed to obtain access token from gcloud. Ensure the workflow is authenticated.');
+    throw error;
+  }
+}
+
+async function triggerRedeploy() {
+  const token = getAccessToken();
+  const url = `https://aistudio.googleapis.com/v1alpha/apps/${AI_STUDIO_APP_ID}:deploy`;
+  const payload = {
+    gitCommitSha: GITHUB_SHA,
+  };
+
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(payload),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    console.error('AI Studio deploy request failed with status', response.status, errorText);
+    process.exit(1);
+  }
+
+  const data = await response.json().catch(() => ({}));
+  console.log('Deployment triggered successfully in AI Studio.');
+  if (Object.keys(data).length > 0) {
+    console.log('Response:', JSON.stringify(data, null, 2));
+  }
+}
+
+triggerRedeploy().catch((error) => {
+  console.error('Failed to trigger AI Studio redeploy:', error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that builds the app and redeploys it to Google AI Studio on pushes to main
- add a Node script wired to an npm command to trigger the AI Studio deployment API using gcloud auth
- document the required GitHub secrets for the automation in the README

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d6d2f0cdc88333a1671fd23f378446